### PR TITLE
Configure gsoci.azurecr.io as the registry to use by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Configure `gsoci.azurecr.io` as the default container image registry.
+
 ## [0.3.4] - 2021-10-12
 
 ### Added

--- a/helm/capi-node-labeler/values.yaml
+++ b/helm/capi-node-labeler/values.yaml
@@ -8,7 +8,7 @@ project:
 image:
   name: "giantswarm/capi-node-labeler-app"
   tag: "[[ .Version ]]"
-  registry: "docker.io"
+  registry: "gsoci.azurecr.io"
 
 pod:
   user:


### PR DESCRIPTION
Towards

- https://github.com/giantswarm/roadmap/issues/3017

This PR replaces any occurrence of `docker.io` in `values.yaml` files with `gsoci.azurecr.io`,
to make the new ACR registry the default one.
