### PR TITLE
Improve control plane node detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Improve Control Plane node detection.
+- Taint Control Plane nodes if not already tainted.
+
 ## [1.0.2] - 2025-03-17
 
 ### Changed

--- a/helm/capi-node-labeler/templates/rbac.yaml
+++ b/helm/capi-node-labeler/templates/rbac.yaml
@@ -18,6 +18,7 @@ rules:
   - pods
   verbs:
   - get
+  - list
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/helm/capi-node-labeler/templates/rbac.yaml
+++ b/helm/capi-node-labeler/templates/rbac.yaml
@@ -12,6 +12,12 @@ rules:
   verbs:
   - get
   - update
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/main.go
+++ b/main.go
@@ -86,7 +86,7 @@ func main() {
 
 	shouldUpdate := false
 	// check if the node is worker or master
-	if isControlPlaneNode(node, ctrlClient) {
+	if isControlPlaneNode(ctx, node, ctrlClient) {
 		// master node
 		if !hasLabel(node.Labels, MasterNodeRoleLabel) {
 			node.Labels[MasterNodeRoleLabel] = ""
@@ -182,7 +182,7 @@ func hasTaint(taints []v1.Taint, taintKey string) bool {
 	return false
 }
 
-func isControlPlaneNode(node v1.Node, ctrlClient client.Client) bool {
+func isControlPlaneNode(ctx context.Context, node v1.Node, ctrlClient client.Client) bool {
 	if hasLabel(node.Labels, MasterNodeRoleLabel) || hasLabel(node.Labels, ControlPlaneNodeRoleLabel) || hasLabel(node.Labels, LegacyMasterNodeLabel) {
 		return true
 	}
@@ -190,14 +190,14 @@ func isControlPlaneNode(node v1.Node, ctrlClient client.Client) bool {
 	// if node doesn't have any of the control plane labels, check if it has control plane Pods running as fallback.
 	// During DR scenarios, the node may not have any of the control plane labels but may still be a control plane node.
 	var apiPods v1.PodList
-	err := ctrlClient.List(context.TODO(), &apiPods, client.InNamespace("kube-system"), client.MatchingLabels{"component": "kube-apiserver", "tier": "control-plane"})
+	err := ctrlClient.List(ctx, &apiPods, client.InNamespace("kube-system"), client.MatchingLabels{"component": "kube-apiserver", "tier": "control-plane"})
 	if err != nil {
 		fmt.Printf("ERROR: failed to list api-server Pods in kube-system namespace\n")
 		panic(err)
 	}
 
 	var etcdPods v1.PodList
-	err = ctrlClient.List(context.TODO(), &etcdPods, client.InNamespace("kube-system"), client.MatchingLabels{"component": "etcd", "tier": "control-plane"})
+	err = ctrlClient.List(ctx, &etcdPods, client.InNamespace("kube-system"), client.MatchingLabels{"component": "etcd", "tier": "control-plane"})
 	if err != nil {
 		fmt.Printf("ERROR: failed to list etcd Pods in kube-system namespace\n")
 		panic(err)


### PR DESCRIPTION
- select CP nodes based on the Pods running on them (additionally to the current label selectors)
- taint CP nodes if not already tainted

These two additions are meant to improve disaster recovery scenarios. After an etcd snapshot restore, the new nodes might join the cluster with a kubelet restart, without going through the entire kubeadm join process. This causes CP nodes to join the new cluster without their labels or taint.

Towards https://github.com/giantswarm/giantswarm/issues/30439